### PR TITLE
Adding inline-style-prefixer as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "url": "https://github.com/bentatum/better-react-spinkit.git"
   },
   "dependencies": {
-    "inline=style-prefixer": "^2.0.1",
+    "inline-style-prefixer": "^2.0.1",
     "lodash.memoize": "^4.0.3",
     "lodash.omitby": "^4.3.0",
     "lodash.range": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "eslint-plugin-jsx-control-statements": "^2.1.1",
     "expect": "^1.20.2",
     "ghooks": "^1.3.2",
-    "inline-style-prefixer": "^2.0.1",
     "jsx-control-statements": "^3.1.2",
     "mocha": "^2.4.5",
     "react": "^15.2.1",
@@ -58,14 +57,12 @@
     "url": "https://github.com/bentatum/better-react-spinkit.git"
   },
   "dependencies": {
+    "inline=style-prefixer": "^2.0.1",
     "lodash.memoize": "^4.0.3",
     "lodash.omitby": "^4.3.0",
     "lodash.range": "^3.1.4",
     "minify-css-string": "^1.0.0",
     "performance-uuid": "^0.1.0"
-  },
-  "peerDependencies": {
-    "inline-style-prefixer": "^2.0.1"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
In order for this to build properly the inline-style-prefixer needs to be a dependency, not a peer dependency.
It's possible that you may actually want this to be a peer-dependency, but I don't see why that would be the case.

http://stackoverflow.com/a/34645112