### PR TITLE
Add reverse prop to Wave component

### DIFF
--- a/src/Wave/index.js
+++ b/src/Wave/index.js
@@ -4,7 +4,7 @@ import { default as range } from 'lodash.range'
 import { default as Base } from '../Base'
 const defaultSize = 22
 
-const Wave = ({ color, columns, columnWidth, gutterWidth, scaleYEnd, scaleYStart, size, ...props }, { betterReactSpinkit = {} }) => {
+const Wave = ({ color, columns, columnWidth, gutterWidth, reverse, scaleYEnd, scaleYStart, size, ...props }, { betterReactSpinkit = {} }) => {
   const name = animationName('wave')
   const finalSize = preside(size, betterReactSpinkit.size, defaultSize)
   const outer = {
@@ -19,6 +19,7 @@ const Wave = ({ color, columns, columnWidth, gutterWidth, scaleYEnd, scaleYStart
     height: '100%',
     width: columnWidth
   }
+  const cols = (reverse) ? range(columns).reverse() : range(columns)
   return (
     <Base
       css={`
@@ -44,7 +45,7 @@ const Wave = ({ color, columns, columnWidth, gutterWidth, scaleYEnd, scaleYStart
       {...props}
     >
       <div style={outer}>
-        {range(columns).map((index) =>
+        {cols.map((index) =>
           <div
             key={index}
             style={{
@@ -77,6 +78,10 @@ Wave.propTypes = {
    */
   gutterWidth: PropTypes.number,
   /**
+   * Reverse the animation.
+   */
+  reverse: PropTypes.bool,
+  /**
    * Ending column height.
    */
   scaleYEnd: PropTypes.number,
@@ -94,6 +99,7 @@ Wave.defaultProps = {
   columns: 5,
   columnWidth: '20%',
   gutterWidth: 1,
+  reverse: false,
   scaleYEnd: 1,
   scaleYStart: 0.4,
   size: defaultSize


### PR DESCRIPTION
The wave animation is right-to-left, but the original Spinkit animation is left-to-right, so I added a reverse prop which makes it animate left-to-right instead.