### PR TITLE
Use prop-types package instead of the bundled prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "lodash.omitby": "^4.3.0",
     "lodash.range": "^3.1.4",
     "minify-css-string": "^1.0.0",
-    "performance-uuid": "^0.1.0"
+    "performance-uuid": "^0.1.0",
+    "prop-types": "^15.5.8"
   },
   "babel": {
     "presets": [

--- a/src/Base/Circle.js
+++ b/src/Base/Circle.js
@@ -1,4 +1,5 @@
-import { default as React, PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import { default as React } from 'react'
 import { default as range } from 'lodash.range'
 import { default as Base } from '.'
 import { animate, defaults, preside } from '../util'

--- a/src/Base/index.js
+++ b/src/Base/index.js
@@ -1,5 +1,6 @@
 
-import { default as React, PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import { default as React } from 'react'
 import { default as minifyCss } from 'minify-css-string'
 
 const Base = ({ css, children, ...props }) =>

--- a/src/ChasingDots/index.js
+++ b/src/ChasingDots/index.js
@@ -1,4 +1,5 @@
-import { default as React, PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import { default as React } from 'react'
 import { animate, animationName, defaults, preside } from '../util'
 import { default as Base } from '../Base'
 const defaultSize = 18

--- a/src/Circle/index.js
+++ b/src/Circle/index.js
@@ -1,4 +1,5 @@
-import { default as React, PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import { default as React } from 'react'
 import { default as BaseCircle } from '../Base/Circle'
 import { animationName } from '../util'
 const defaultSize = 22

--- a/src/CubeGrid/index.js
+++ b/src/CubeGrid/index.js
@@ -1,4 +1,5 @@
-import { default as React, PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import { default as React } from 'react'
 import { default as Base } from '../Base'
 import { default as memoize } from 'lodash.memoize'
 import { default as range } from 'lodash.range'

--- a/src/DoubleBounce/index.js
+++ b/src/DoubleBounce/index.js
@@ -1,4 +1,5 @@
-import { default as React, PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import { default as React } from 'react'
 import { animate, animationName, defaults, preside } from '../util'
 import { default as Base } from '../Base'
 const defaultSize = 18

--- a/src/FadingCircle/index.js
+++ b/src/FadingCircle/index.js
@@ -1,4 +1,5 @@
-import { default as React, PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import { default as React } from 'react'
 import { default as BaseCircle } from '../Base/Circle'
 import { animationName } from '../util'
 const defaultSize = 22

--- a/src/FoldingCube/index.js
+++ b/src/FoldingCube/index.js
@@ -1,4 +1,5 @@
-import { default as React, PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import { default as React } from 'react'
 import { default as Base } from '../Base'
 import { default as range } from 'lodash.range'
 import { animate, animationName, defaults, preside } from '../util'

--- a/src/Pulse/index.js
+++ b/src/Pulse/index.js
@@ -1,4 +1,5 @@
-import { default as React, PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import { default as React } from 'react'
 import { default as Base } from '../Base'
 import { animate, animationName, defaults, preside } from '../util'
 const defaultSize = 20

--- a/src/RotatingPlane/index.js
+++ b/src/RotatingPlane/index.js
@@ -1,4 +1,5 @@
-import { default as React, PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import { default as React } from 'react'
 import { animate, animationName, defaults, preside } from '../util'
 import { default as Base } from '../Base'
 const defaultSize = 18

--- a/src/ThreeBounce/index.js
+++ b/src/ThreeBounce/index.js
@@ -1,4 +1,5 @@
-import { default as React, PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import { default as React } from 'react'
 import { default as Base } from '../Base'
 import { animate, animationName, defaults, preside } from '../util'
 const defaultSize = 10

--- a/src/WanderingCubes/index.js
+++ b/src/WanderingCubes/index.js
@@ -1,4 +1,5 @@
-import { default as React, PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import { default as React } from 'react'
 import { default as Base } from '../Base'
 import { animate, animationName, defaults, preside } from '../util'
 const defaultSize = 16

--- a/src/Wave/index.js
+++ b/src/Wave/index.js
@@ -1,4 +1,5 @@
-import { default as React, PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import { default as React } from 'react'
 import { animate, animationName, defaults, preside } from '../util'
 import { default as range } from 'lodash.range'
 import { default as Base } from '../Base'

--- a/src/Wordpress/index.js
+++ b/src/Wordpress/index.js
@@ -1,4 +1,5 @@
-import { default as React, PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import { default as React } from 'react'
 import { animate, animationName, defaults, preside } from '../util'
 import { default as Base } from '../Base'
 const defaultSize = 18

--- a/src/util/defaults.js
+++ b/src/util/defaults.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react'
+import PropTypes from 'prop-types'
 
 export const contextTypes = {
   betterReactSpinkit: PropTypes.shape({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1421,7 +1421,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
+fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.9"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.9.tgz#180247fbd347dcc9004517b904f865400a0c8f14"
   dependencies:
@@ -2594,6 +2594,12 @@ promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+prop-types@^15.5.8:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
 
 pseudomap@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
The `React.PropTypes` have been deprecated and moved to `prop-types` package. Replaces instances of `React.PropTypes` with the `prop-types` package to remove deprecation warnings from current users.

For more information see https://facebook.github.io/react/warnings/dont-call-proptypes.html

Signed-off-by: petetnt <pete.a.nykanen@gmail.com>