### PR TITLE
Import specific lodash submodules.

### DIFF
--- a/src/Base/Circle.js
+++ b/src/Base/Circle.js
@@ -1,7 +1,7 @@
 
 import Base from '.'
 import React from 'react'
-import { range } from 'lodash'
+import range from 'lodash/range'
 import PropTypes from 'prop-types'
 import { animate, defaults, preside } from '../util'
 import Prefixer from 'inline-style-prefixer'

--- a/src/CubeGrid/index.js
+++ b/src/CubeGrid/index.js
@@ -2,7 +2,8 @@
 import React from 'react'
 import Base from '../Base'
 import PropTypes from 'prop-types'
-import { range, memoize } from 'lodash'
+import range from 'lodash/range'
+import memoize from 'lodash/memoize'
 import randomDelays from './randomDelays'
 import { animate, animationName, defaults, preside } from '../util'
 

--- a/src/FoldingCube/index.js
+++ b/src/FoldingCube/index.js
@@ -1,7 +1,7 @@
 
 import React from 'react'
 import Base from '../Base'
-import { range } from 'lodash'
+import range from 'lodash/range'
 import PropTypes from 'prop-types'
 import cubeDelay from './cubeDelay'
 import cubeRotateZ from './cubeRotateZ'

--- a/src/Wave/index.js
+++ b/src/Wave/index.js
@@ -1,7 +1,7 @@
 
 import React from 'react'
 import Base from '../Base'
-import { range } from 'lodash'
+import range from 'lodash/range'
 import PropTypes from 'prop-types'
 import { animate, animationName, defaults, preside } from '../util'
 

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -1,5 +1,5 @@
 
-import { omitBy } from 'lodash'
+import omitBy from 'lodash/omitBy'
 import { default as Prefixer } from 'inline-style-prefixer'
 const prefixer = new Prefixer()
 


### PR DESCRIPTION
The problem with https://github.com/bentatum/better-react-spinkit/issues/11 is that for people who don't use lodash, better-react-spinkit is now pulling in the full library. That seems quite unnecessary. 