### PR TITLE
Remove auto generated id. Closes #10

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   },
   "dependencies": {
     "inline-style-prefixer": "^3.0.3",
-    "minify-css-string": "^1.0.0",
-    "performance-uuid": "^0.1.0"
+    "minify-css-string": "^1.0.0"
   },
   "peerDependencies": {
     "prop-types": "^15.5.8",

--- a/src/util/animationName.js
+++ b/src/util/animationName.js
@@ -1,3 +1,1 @@
-import { default as uuid } from 'performance-uuid'
-
-export default (name = 'spinner') => `brsk-${name}-${uuid()}`
+export default (name = 'spinner') => `brsk-${name}`

--- a/yarn.lock
+++ b/yarn.lock
@@ -2753,10 +2753,6 @@ path-key@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-1.0.0.tgz#5d53d578019646c0d68800db4e146e6bdc2ac7af"
 
-performance-uuid@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/performance-uuid/-/performance-uuid-0.1.0.tgz#30bef45e85950fa545ef818c67d3bc7fd0459843"
-
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"


### PR DESCRIPTION
With this fix, there is no auto-generated id, so that server and client has got the `same animation name`.