### PR TITLE
Improve bundle size by using lodash sub-modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,17 @@
   },
   "dependencies": {
     "inline-style-prefixer": "^3.0.3",
+    "lodash.memoize": "^4.1.2",
+    "lodash.omitby": "^4.6.0",
+    "lodash.range": "^3.2.0",
     "minify-css-string": "^1.0.0"
   },
   "peerDependencies": {
     "prop-types": "^15.5.8",
-    "react": "^15.5.4",
-    "lodash": "^4.17.4"
+    "lodash.memoize": "^4.1.2",
+    "lodash.omitby": "^4.6.0",
+    "lodash.range": "^3.2.0",
+    "react": "^15.5.4"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -41,7 +46,6 @@
     "ghooks": "^2.0.0",
     "husky": "^0.13.3",
     "jsx-control-statements": "^3.1.2",
-    "lodash": "^4.17.4",
     "mocha": "^3.3.0",
     "prop-types": "^15.5.8",
     "react": "^15.5.4",

--- a/src/Base/Circle.js
+++ b/src/Base/Circle.js
@@ -1,7 +1,7 @@
 
 import Base from '.'
 import React from 'react'
-import { range } from 'lodash'
+import range from 'lodash.range'
 import PropTypes from 'prop-types'
 import { animate, defaults, preside } from '../util'
 import Prefixer from 'inline-style-prefixer'

--- a/src/CubeGrid/index.js
+++ b/src/CubeGrid/index.js
@@ -2,7 +2,8 @@
 import React from 'react'
 import Base from '../Base'
 import PropTypes from 'prop-types'
-import { range, memoize } from 'lodash'
+import range from 'lodash.range'
+import memoize from 'lodash.memoize'
 import randomDelays from './randomDelays'
 import { animate, animationName, defaults, preside } from '../util'
 

--- a/src/FoldingCube/index.js
+++ b/src/FoldingCube/index.js
@@ -1,7 +1,7 @@
 
 import React from 'react'
 import Base from '../Base'
-import { range } from 'lodash'
+import range from 'lodash.range'
 import PropTypes from 'prop-types'
 import cubeDelay from './cubeDelay'
 import cubeRotateZ from './cubeRotateZ'

--- a/src/Wave/index.js
+++ b/src/Wave/index.js
@@ -1,7 +1,7 @@
 
 import React from 'react'
 import Base from '../Base'
-import { range } from 'lodash'
+import range from 'lodash.range'
 import PropTypes from 'prop-types'
 import { animate, animationName, defaults, preside } from '../util'
 

--- a/src/util/animate.js
+++ b/src/util/animate.js
@@ -1,5 +1,5 @@
 
-import { omitBy } from 'lodash'
+import omitBy from 'lodash.omitby'
 import prefix from 'inline-style-prefixer/static'
 
 export default ({ delay, duration, fillMode, iterationCount, name, timingFunction }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2421,11 +2421,23 @@ lodash.map@^4.5.1:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
 
+lodash.memoize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+
+lodash.omitby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.omitby/-/lodash.omitby-4.6.0.tgz#5c15ff4754ad555016b53c041311e8f079204791"
+
+lodash.range@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.range/-/lodash.range-3.2.0.tgz#f461e588f66683f7eadeade513e38a69a565a15d"
+
 lodash@4.17.2:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
 
-lodash@^4.0.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
For example, when using in app:

**With optimisation:**

  144.47 KB  build/static/js/main.e189deef.js
  483 B      build/static/css/main.08f5022c.css

**Without optimisation:**

  156.94 KB (+12.47 KB)  build/static/js/main.5906100c.js
  483 B                  build/static/css/main.08f5022c.css

Fixes issue #22 