### PR TITLE
Upgrading to react 16.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "minify-css-string": "^1.0.0"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.8",
-    "react": "^15.5.4",
+    "prop-types": "^15.6.0",
+    "react": "^16.2.0",
     "lodash": "^4.17.4"
   },
   "devDependencies": {
@@ -44,9 +44,9 @@
     "lodash": "^4.17.4",
     "mocha": "^3.3.0",
     "prop-types": "^15.5.8",
-    "react": "^15.5.4",
-    "react-addons-test-utils": "^15.5.1",
-    "react-dom": "^15.5.4",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
+    "react-test-renderer": "^16.2.0",
     "standard": "^10.0.2",
     "validate-commit-msg": "^2.12.1"
   },

--- a/src/Base/__spec__/index.spec.js
+++ b/src/Base/__spec__/index.spec.js
@@ -1,9 +1,9 @@
 import { default as React } from 'react'
-import { default as TestUtils } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import { default as expect } from 'expect'
 import { default as Base } from '..'
 
-const renderer = TestUtils.createRenderer()
+const renderer = createRenderer()
 
 describe('Base', () => {
   let outer, style

--- a/src/ChasingDots/__spec__/index.spec.js
+++ b/src/ChasingDots/__spec__/index.spec.js
@@ -1,10 +1,10 @@
 import { default as React } from 'react'
-import { default as TestUtils } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import { default as expect } from 'expect'
 import { default as ChasingDots } from '..'
 import { default as Base } from '../../Base'
 
-const renderer = TestUtils.createRenderer()
+const renderer = createRenderer()
 
 describe('ChasingDots', () => {
   let tree

--- a/src/Circle/__spec__/index.spec.js
+++ b/src/Circle/__spec__/index.spec.js
@@ -1,10 +1,10 @@
 import { default as React } from 'react'
-import { default as TestUtils } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import { default as expect } from 'expect'
 import { default as Circle } from '..'
 import { default as BaseCircle } from '../../Base/Circle'
 
-const renderer = TestUtils.createRenderer()
+const renderer = createRenderer()
 
 describe('Circle', () => {
   let tree

--- a/src/CubeGrid/__spec__/index.spec.js
+++ b/src/CubeGrid/__spec__/index.spec.js
@@ -1,10 +1,10 @@
 import { default as React } from 'react'
-import { default as TestUtils } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import { default as expect } from 'expect'
 import { default as CubeGrid } from '..'
 import { default as Base } from '../../Base'
 
-const renderer = TestUtils.createRenderer()
+const renderer = createRenderer()
 
 describe('CubeGrid', () => {
   let tree

--- a/src/DoubleBounce/__spec__/index.spec.js
+++ b/src/DoubleBounce/__spec__/index.spec.js
@@ -1,10 +1,10 @@
 import { default as React } from 'react'
-import { default as TestUtils } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import { default as expect } from 'expect'
 import { default as DoubleBounce } from '..'
 import { default as Base } from '../../Base'
 
-const renderer = TestUtils.createRenderer()
+const renderer = createRenderer()
 
 describe('DoubleBounce', () => {
   let tree

--- a/src/FadingCircle/__spec__/index.spec.js
+++ b/src/FadingCircle/__spec__/index.spec.js
@@ -1,10 +1,10 @@
 import { default as React } from 'react'
-import { default as TestUtils } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import { default as expect } from 'expect'
 import { default as FadingCircle } from '..'
 import { default as BaseCircle } from '../../Base/Circle'
 
-const renderer = TestUtils.createRenderer()
+const renderer = createRenderer()
 
 describe('FadingCircle', () => {
   let tree

--- a/src/FoldingCube/__spec__/index.spec.js
+++ b/src/FoldingCube/__spec__/index.spec.js
@@ -1,10 +1,10 @@
 import { default as React } from 'react'
-import { default as TestUtils } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import { default as expect } from 'expect'
 import { default as FoldingCube } from '..'
 import { default as Base } from '../../Base'
 
-const renderer = TestUtils.createRenderer()
+const renderer = createRenderer()
 
 describe('FoldingCube', () => {
   let tree

--- a/src/Pulse/__spec__/index.spec.js
+++ b/src/Pulse/__spec__/index.spec.js
@@ -1,10 +1,10 @@
 import { default as React } from 'react'
-import { default as TestUtils } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import { default as expect } from 'expect'
 import { default as Pulse } from '..'
 import { default as Base } from '../../Base'
 
-const renderer = TestUtils.createRenderer()
+const renderer = createRenderer()
 
 describe('Pulse', () => {
   let tree

--- a/src/RotatingPlane/__spec__/index.spec.js
+++ b/src/RotatingPlane/__spec__/index.spec.js
@@ -1,10 +1,10 @@
 import { default as React } from 'react'
-import { default as TestUtils } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import { default as expect } from 'expect'
 import { default as RotatingPlane } from '..'
 import { default as Base } from '../../Base'
 
-const renderer = TestUtils.createRenderer()
+const renderer = createRenderer()
 
 describe('RotatingPlane', () => {
   let tree

--- a/src/ThreeBounce/__spec__/index.spec.js
+++ b/src/ThreeBounce/__spec__/index.spec.js
@@ -1,10 +1,10 @@
 import { default as React } from 'react'
-import { default as TestUtils } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import { default as expect } from 'expect'
 import { default as ThreeBounce } from '..'
 import { default as Base } from '../../Base'
 
-const renderer = TestUtils.createRenderer()
+const renderer = createRenderer()
 
 describe('ThreeBounce', () => {
   let tree

--- a/src/WanderingCubes/__spec__/index.spec.js
+++ b/src/WanderingCubes/__spec__/index.spec.js
@@ -1,10 +1,10 @@
 import { default as React } from 'react'
-import { default as TestUtils } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import { default as expect } from 'expect'
 import { default as WanderingCubes } from '..'
 import { default as Base } from '../../Base'
 
-const renderer = TestUtils.createRenderer()
+const renderer = createRenderer()
 
 describe('WanderingCubes', () => {
   let tree

--- a/src/Wave/__spec__/index.spec.js
+++ b/src/Wave/__spec__/index.spec.js
@@ -1,10 +1,10 @@
 import { default as React } from 'react'
-import { default as TestUtils } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import { default as expect } from 'expect'
 import { default as Wave } from '..'
 import { default as Base } from '../../Base'
 
-const renderer = TestUtils.createRenderer()
+const renderer = createRenderer()
 
 describe('Wave', () => {
   let tree

--- a/src/Wordpress/__spec__/index.spec.js
+++ b/src/Wordpress/__spec__/index.spec.js
@@ -1,10 +1,10 @@
 import { default as React } from 'react'
-import { default as TestUtils } from 'react-addons-test-utils'
+import { createRenderer } from 'react-test-renderer/shallow'
 import { default as expect } from 'expect'
 import { default as Wordpress } from '..'
 import { default as Base } from '../../Base'
 
-const renderer = TestUtils.createRenderer()
+const renderer = createRenderer()
 
 describe('Wordpress', () => {
   let tree

--- a/yarn.lock
+++ b/yarn.lock
@@ -1595,7 +1595,19 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
+fbjs@^0.8.9:
   version "0.8.9"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.9.tgz#180247fbd347dcc9004517b904f865400a0c8f14"
   dependencies:
@@ -2433,7 +2445,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -2604,7 +2616,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -2824,11 +2836,19 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
+prop-types@^15.5.8:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
     fbjs "^0.8.9"
+
+prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 pseudomap@^1.0.1:
   version "1.0.2"
@@ -2858,30 +2878,31 @@ rc@~1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-addons-test-utils@^15.5.1:
-  version "15.5.1"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.5.1.tgz#e0d258cda2a122ad0dff69f838260d0c3958f5f7"
+react-dom@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
   dependencies:
-    fbjs "^0.8.4"
-    object-assign "^4.1.0"
-
-react-dom@^15.5.4:
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
-  dependencies:
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "~15.5.7"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
-react@^15.5.4:
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
+react-test-renderer@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
   dependencies:
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+  dependencies:
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.7"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.2.2:
   version "2.2.3"


### PR DESCRIPTION
`react-addons-test-utils` was deprecated and moved into `react-test-renderer/shallow` as well.

I'm sorry that breaks the nice looking test imports 😂 